### PR TITLE
Make getString() work with any type of value

### DIFF
--- a/JsonObjectBase.cpp
+++ b/JsonObjectBase.cpp
@@ -57,7 +57,7 @@ long JsonObjectBase::getLongFromToken(jsmntok_t* token)
 
 char* JsonObjectBase::getStringFromToken(jsmntok_t* token)
 {
-	if (token == 0 || token->type != JSMN_PRIMITIVE && token->type != JSMN_STRING)
+	if (token == 0 || token->type != JSMN_PRIMITIVE && token->type != JSMN_STRING && token->type != JSMN_OBJECT)
 		return 0;
 
 	// add null terminator to the string


### PR DESCRIPTION
{"value":{"name":"test"}, "id": 10} can be parsed, now. If an attribute defines an object, the corresponding string can be received by hashTable.getString("value"). The JSON parser can then process the received object again (JsonHashTable valueHashTable = parser.parseHashTable(hashTable.getString("value"));) and hold the contents in a new hashtable.
