### PR TITLE
convert long to double

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 /build
 /bin
 /lib
+*.cmake
+CMakeCache.txt
+CMakeFiles
+Makefile
+core

--- a/src/Internals/JsonParser.cpp
+++ b/src/Internals/JsonParser.cpp
@@ -89,6 +89,9 @@ void JsonParser::parseAnythingTo(JsonVariant &destination) {
 JsonArray &JsonParser::parseArray() {
   // Create an empty array
   JsonArray &array = _buffer->createArray();
+  if (!array.success()) {
+  	goto ERROR_ARRAY_CREATE;
+  }
 
   // Check opening braket
   if (!skip('[')) goto ERROR_MISSING_BRACKET;
@@ -98,6 +101,9 @@ JsonArray &JsonParser::parseArray() {
   for (;;) {
     // 1 - Parse value
     JsonVariant &value = array.add();
+	if (&value == &JsonVariant::invalid()) {
+		goto ERROR_ARRAY_ADD;
+	}
     parseAnythingTo(value);
     if (!value.success()) goto ERROR_INVALID_VALUE;
 
@@ -110,6 +116,8 @@ SUCCESS_EMPTY_ARRAY:
 SUCCES_NON_EMPTY_ARRAY:
   return array;
 
+ERROR_ARRAY_CREATE:
+ERROR_ARRAY_ADD:
 ERROR_INVALID_VALUE:
 ERROR_MISSING_BRACKET:
 ERROR_MISSING_COMMA:
@@ -119,6 +127,9 @@ ERROR_MISSING_COMMA:
 JsonObject &JsonParser::parseObject() {
   // Create an empty object
   JsonObject &object = _buffer->createObject();
+  if (!object.success()) {
+  	goto ERROR_OBJECT_CREATE;
+  }
 
   // Check opening brace
   if (!skip('{')) goto ERROR_MISSING_BRACE;
@@ -133,6 +144,9 @@ JsonObject &JsonParser::parseObject() {
 
     // 2 - Parse value
     JsonVariant &value = object.add(key);
+	if (&value == &JsonVariant::invalid()) {
+		goto ERROR_OBJECT_ADD;
+	}
     parseAnythingTo(value);
     if (!value.success()) goto ERROR_INVALID_VALUE;
 
@@ -145,6 +159,8 @@ SUCCESS_EMPTY_OBJECT:
 SUCCESS_NON_EMPTY_OBJECT:
   return object;
 
+ERROR_OBJECT_CREATE:
+ERROR_OBJECT_ADD:
 ERROR_INVALID_KEY:
 ERROR_INVALID_VALUE:
 ERROR_MISSING_BRACE:

--- a/src/JsonVariant.cpp
+++ b/src/JsonVariant.cpp
@@ -31,6 +31,9 @@ JsonVariant::operator const char *() const {
 }
 
 JsonVariant::operator double() const {
+  if (_type == JSON_LONG) {
+  	return static_cast<double>(_content.asLong);
+  }
   return _type >= JSON_DOUBLE_0_DECIMALS ? _content.asDouble : 0;
 }
 


### PR DESCRIPTION
Benoit,

Many thanks for ArduinoJson. I intend to use it in FirePick Delta for CNC motion control adopting a JSON style of interaction modeled after TinyG. I do very much like your library. For larger projects I use Jansson, but your library is excellent for Arduino with its smaller footprint.

On a minor note, I made a small modification that you may or may not want. I convert long to double automatically. For me this simplifies my code so that I can deal with numbers as double regardless. I'm happy working off my fork--that's the only thing I had to change.  I know that it's a slippery slope doing this type of "nice conversion." In this case, I found it worthwhile on the client side. The alternate solution is to provide a new utility method (e.g., asNumber()). After careful consideration, I chose this as less invasive of the API.

Anyhow, thanks for ArduinoJson!