### PR TITLE
Add library category

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Benoit Blanchon <blog.benoitblanchon.fr>
 maintainer=Benoit Blanchon <blog.benoitblanchon.fr>
 sentence=An efficient and elegant JSON library for Arduino.
 paragraph=Like this project? Please star it on GitHub!
+category=Data Processing
 url=https://github.com/bblanchon/ArduinoJson
 architectures=*


### PR DESCRIPTION
Add library category as documented [here](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format).

This prevents a Warning in the new Arduino 1.6.6.