### PR TITLE
Do not override key if node exists, save memory for override value cases

### DIFF
--- a/include/ArduinoJson/JsonObject.ipp
+++ b/include/ArduinoJson/JsonObject.ipp
@@ -55,8 +55,12 @@ inline void JsonObject::remove(JsonObjectKey key) {
 template <typename T>
 inline bool JsonObject::setNodeAt(JsonObjectKey key, T value) {
   node_type *node = getNodeAt(key.c_str());
-  if (!node) node = addNewNode();
-  return node && setNodeKey(node, key) && setNodeValue<T>(node, value);
+  if (!node) {
+    node = addNewNode();
+    if (!node || !setNodeKey(node, key))
+      return false;
+  }
+  return setNodeValue<T>(node, value);
 }
 
 inline bool JsonObject::setNodeKey(node_type *node, JsonObjectKey key) {


### PR DESCRIPTION
When override object value, the node exists case, can avoid set key to save memory, specially for String key case.