### PR TITLE
String: fix define check

### DIFF
--- a/include/ArduinoJson/String.hpp
+++ b/include/ArduinoJson/String.hpp
@@ -9,7 +9,7 @@
 
 #include "Configuration.hpp"
 
-#if ARDUINOJSON_USE_ARDUINO_STRING
+#ifdef ARDUINOJSON_USE_ARDUINO_STRING
 
 #include <WString.h>
 


### PR DESCRIPTION
The current test fails with the following error when using  `#define ARDUINOJSON_USE_ARDUINO_STRING`
```
../..//src/third-party/arduino-json-5.6.2/include/ArduinoJson/Internals/../Internals/../String.hpp:12:35: error: #if with no expression
 #if ARDUINOJSON_USE_ARDUINO_STRING
```