### PR TITLE
Update JsonHttpClient.ino / Sockets error

### DIFF
--- a/examples/JsonHttpClient/JsonHttpClient.ino
+++ b/examples/JsonHttpClient/JsonHttpClient.ino
@@ -41,8 +41,8 @@ void loop() {
         printUserData(&userData);
       }
     }
-    disconnect();
   }
+  disconnect();
   wait();
 }
 


### PR DESCRIPTION
Because of opened sockets also after connections errors, the sockets / connections has to be closed.