### PR TITLE
Delete the copy constructor and copy assignment operators for StaticJsonBufferBase.

### DIFF
--- a/src/ArduinoJson/StaticJsonBuffer.hpp
+++ b/src/ArduinoJson/StaticJsonBuffer.hpp
@@ -71,6 +71,9 @@ class StaticJsonBufferBase : public JsonBufferBase<StaticJsonBufferBase> {
     return String(this);
   }
 
+  StaticJsonBufferBase(const StaticJsonBufferBase&) = delete;
+  StaticJsonBufferBase& operator=(const StaticJsonBufferBase&) = delete;
+
  private:
   void alignNextAlloc() {
     _size = round_size_up(_size);


### PR DESCRIPTION
These are always invalid, regardless of usage of objects created in the
buffer(s). The root of the problem with using the default copy operators is that
the `_buffer` pointer is copied as well, which means that the copied-to buffer
now points to the copied-from buffer's memory.

Consider the clearing example at the bottom of
https://bblanchon.github.io/ArduinoJson/faq/how-to-reuse-a-jsonbuffer/

```
StaticJsonBuffer<200> buf{};

JsonObject& obj = buf.createObject();
// Use obj, etc.

buf = StaticJsonBuffer<200>();
// StaticJsonBufferBase::_buffer points to deallocated memory of the temporary

JsonObject& new_obj = buf.createObject();
// Even if I never touch `obj` again, new_obj can easily become corrupted.
```

Properly implemented copy operators will have to be provided by the concrete
buffer types (e.g. `StaticJsonBuffer`) and something sensible needs to be
done about mis-matched capacities.