### PR TITLE
Adjust nest level counting to make it algebraically coherent

### DIFF
--- a/src/ArduinoJson/Deserialization/JsonParser.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParser.hpp
@@ -30,7 +30,7 @@ class JsonParser {
 
   JsonVariant parseVariant() {
     JsonVariant result;
-    parseAnythingToUnsafe(&result);
+    parseAnythingTo(&result);
     return result;
   }
 
@@ -44,7 +44,7 @@ class JsonParser {
 
   const char *parseString();
   bool parseAnythingTo(JsonVariant *destination);
-  FORCE_INLINE bool parseAnythingToUnsafe(JsonVariant *destination);
+  //FORCE_INLINE bool parseAnythingToUnsafe(JsonVariant *destination);
 
   inline bool parseArrayTo(JsonVariant *destination);
   inline bool parseObjectTo(JsonVariant *destination);

--- a/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
@@ -20,17 +20,6 @@ template <typename TReader, typename TWriter>
 inline bool
 ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseAnythingTo(
     JsonVariant *destination) {
-  if (_nestingLimit == 0) return false;
-  _nestingLimit--;
-  bool success = parseAnythingToUnsafe(destination);
-  _nestingLimit++;
-  return success;
-}
-
-template <typename TReader, typename TWriter>
-inline bool
-ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseAnythingToUnsafe(
-    JsonVariant *destination) {
   skipSpacesAndComments(_reader);
 
   switch (_reader.current()) {
@@ -81,7 +70,12 @@ ERROR_NO_MEMORY:
 template <typename TReader, typename TWriter>
 inline bool ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseArrayTo(
     JsonVariant *destination) {
+  if (_nestingLimit == 0) return false;
+  _nestingLimit--;
+
   JsonArray &array = parseArray();
+
+  _nestingLimit++;
   if (!array.success()) return false;
 
   *destination = array;
@@ -131,7 +125,12 @@ ERROR_NO_MEMORY:
 template <typename TReader, typename TWriter>
 inline bool ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseObjectTo(
     JsonVariant *destination) {
+  if (_nestingLimit == 0) return false;
+  _nestingLimit--;
+
   JsonObject &object = parseObject();
+
+  _nestingLimit++;
   if (!object.success()) return false;
 
   *destination = object;

--- a/test/JsonBuffer/nestingLimit.cpp
+++ b/test/JsonBuffer/nestingLimit.cpp
@@ -48,8 +48,10 @@ TEST_CASE("JsonParser nestingLimit") {
   SECTION("parse()") {
     SECTION("limit = 0") {
       SHOULD_WORK(jb.parse("\"toto\"", 0));
-      SHOULD_WORK(jb.parse("[]", 0));
-      SHOULD_WORK(jb.parse("{}", 0));
+      SHOULD_WORK(jb.parse("123", 0));
+      SHOULD_WORK(jb.parse("true", 0));
+      SHOULD_FAIL(jb.parse("[]", 0));
+      SHOULD_FAIL(jb.parse("{}", 0));
       SHOULD_FAIL(jb.parse("[\"toto\"]", 0));
       SHOULD_FAIL(jb.parse("{\"toto\":1}", 0));
     }
@@ -57,6 +59,8 @@ TEST_CASE("JsonParser nestingLimit") {
     SECTION("limit = 1") {
       SHOULD_WORK(jb.parse("[\"toto\"]", 1));
       SHOULD_WORK(jb.parse("{\"toto\":1}", 1));
+      SHOULD_FAIL(jb.parse("{\"toto\":{}}", 1));
+      SHOULD_FAIL(jb.parse("{\"toto\":[]}", 1));
       SHOULD_FAIL(jb.parse("[[\"toto\"]]", 1));
       SHOULD_FAIL(jb.parse("[{\"toto\":1}]", 1));
     }


### PR DESCRIPTION
I am proposing a small adjustment to the nest level counting so that it is more coherent:
1. Simple values (boolean, string, number) are of nest level 0
2. Each layer of object/array increase the nest level by 1

This resolves the nest level loophole when programatically generating nested structures:
Before:
- when inserting a simple value (nest level 0) to a flat array (nest level 0)
  - The result can be serialized and parsed back with nest limit of 0
  - Nest level: 0 + 0 = 0
- But when inserting a flat object (nest level 0) to a flat array (nest level 0)
  - The result **cannot** be serialized and parsed back with nest limit of 0
  - Nest level: 0 + 0 = 1

After:
- Inserting a single value (nest level 0) to a flat object (nest level 1):
  - The result can be serialized and parsed back with nest limit of 1
  - Nest level: 0 + 1 = 1
- Inserting a flat object (nest level 1) to a flat array (nest level 1):
  - The result can be serialized and parsed back with nest limit of 2
  - Nest level: 1 + 1 = 2

As a (possibly good) side effect, this patch also makes the parseAnythingToUnsafe() method unnecessary.