### PR TITLE
Allow passing allocator instance into dynamic buffer

### DIFF
--- a/src/ArduinoJson/DynamicJsonBuffer.hpp
+++ b/src/ArduinoJson/DynamicJsonBuffer.hpp
@@ -7,6 +7,7 @@
 #include "JsonBufferBase.hpp"
 
 #include <stdlib.h>
+#include <utility>
 
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -48,6 +49,10 @@ class DynamicJsonBufferBase
 
   DynamicJsonBufferBase(size_t initialSize = 256)
       : _head(NULL), _nextBlockCapacity(initialSize) {}
+
+  DynamicJsonBufferBase(TAllocator && allocator, size_t initialSize = 256)
+      : _head(NULL), _nextBlockCapacity(initialSize)
+      , _allocator(std::move(allocator))  {}
 
   ~DynamicJsonBufferBase() {
     clear();


### PR DESCRIPTION
I've encountered a scenario and found this feature useful.

- I am writing a utility which provides a more high-level API to allow user program to manipulate json more easily.
  1. I do like to enable user program to specify a buffer limit, however there is no uniform value across all use cases.
  2. In my utility workflow, I need to pass the json buffer instance to the user program so they can load arbitrary json structure using parse() method

I think templating and static json buffer is a possibility, however, the syntax can get quite messy for the callback passing the static json buffer instance. Also, templating cannot support runtime reconfiguration.

So I played around with the dynamic json buffer and allocator, basically creating my own allocator which counts the number of bytes allocated and stops giving out more memory when limit reached. It seems to work well.

This patch basically allows to write a single run-time-configurable-limit allocator and pass it into the DynamicJsonBufferBase.

Alternatively, instead of:
```
TAllocator _allocator;
```
the DynamicJsonBufferBase can declare:
```
TAllocator &_allocator;
```
This would allow even more runtime flexibility (allocator behavior can be reconfigured even after dynamic json buffer has been created).