### PR TITLE
Add attributes to buffers

### DIFF
--- a/src/ArduinoJson/Configuration.hpp
+++ b/src/ArduinoJson/Configuration.hpp
@@ -149,3 +149,9 @@
 #if ARDUINOJSON_USE_LONG_LONG && ARDUINOJSON_USE_INT64
 #error ARDUINOJSON_USE_LONG_LONG and ARDUINOJSON_USE_INT64 cannot be set together
 #endif
+
+// add attributes to buffers
+// e.g. alignment
+#ifndef ARDUINOJSON_STATIC_STORAGE_DECORATION
+#define ARDUINOJSON_STATIC_STORAGE_DECORATION
+#endif

--- a/src/ArduinoJson/StaticJsonBuffer.hpp
+++ b/src/ArduinoJson/StaticJsonBuffer.hpp
@@ -113,7 +113,7 @@ class StaticJsonBuffer : public Internals::StaticJsonBufferBase {
       : Internals::StaticJsonBufferBase(_buffer, CAPACITY) {}
 
  private:
-  char _buffer[CAPACITY];
+  char _buffer[CAPACITY] ARDUINOJSON_STATIC_STORAGE_DECORATION;
 };
 }
 


### PR DESCRIPTION
I added support which allows user to put attributes to arrays.
The need appears when a processor, in my case a DSP, requires to have _buffer aligned at 8 bytes, so in this case the syntax should be : 
 char _buffer[CAPACITY] **__attribute__ ((aligned(8)))**;
