### PR TITLE
strcmp() null pointer guards

### DIFF
--- a/src/ArduinoJson/StringTraits/CharPointer.hpp
+++ b/src/ArduinoJson/StringTraits/CharPointer.hpp
@@ -30,6 +30,7 @@ struct CharPointerTraits {
   };
 
   static bool equals(const TChar* str, const char* expected) {
+    if (!str || !expected) return false;
     return strcmp(reinterpret_cast<const char*>(str), expected) == 0;
   }
 

--- a/src/ArduinoJson/StringTraits/FlashString.hpp
+++ b/src/ArduinoJson/StringTraits/FlashString.hpp
@@ -31,6 +31,7 @@ struct StringTraits<const __FlashStringHelper*, void> {
   };
 
   static bool equals(const __FlashStringHelper* str, const char* expected) {
+    if (!str || !expected) return false;
     return strcmp_P(expected, (const char*)str) == 0;
   }
 

--- a/src/ArduinoJson/StringTraits/StdString.hpp
+++ b/src/ArduinoJson/StringTraits/StdString.hpp
@@ -40,6 +40,7 @@ struct StdStringTraits {
   };
 
   static bool equals(const TString& str, const char* expected) {
+    if (!str.c_str() || !expected) return false;
     return 0 == strcmp(str.c_str(), expected);
   }
 


### PR DESCRIPTION
`strcmp()` is platform dependent and its handling of null pointers is undefined.

In the event of memory problems with the original JSON string being parsed, bad pointers can be erroneously processed in string comparison (or worse) among StringTraits. These guards can help parsing gracefully fail in bad memory edge cases.