### PR TITLE
Implement support for \uxxxx escape sequences. Fixes #304

### DIFF
--- a/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
@@ -149,13 +149,11 @@ static inline void encode_to_utf8(const uint16_t codepoint, Str &str) {
   }
 }
 
-inline char parse_hexdigit(char c) {
-  if (c >= '0' && c <= '9') return static_cast<char>(c - '0');
+static inline char parse_hexdigit(char c) {
+  if (c < 'A')
+      return static_cast<char>(c - '0');
   c &= ~0x20;
-  if (c >= 'A' && c <= 'F')
-    return static_cast<char>(c - 'A' + 10);
-  else
-    return 0;
+  return static_cast<char>(c - 'A' + 10);
 }
 
 template <typename TReader, typename TWriter>

--- a/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
@@ -137,14 +137,15 @@ inline bool ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseObjectTo(
 
 template <typename Str>
 static inline void encode_to_utf8(const uint16_t codepoint, Str &str) {
-    if (codepoint < 0x80) {
-        str.append(static_cast<char>(codepoint));
-        return;
-    }
+  if (codepoint < 0x80) {
+    str.append(static_cast<char>(codepoint));
+    return;
+  }
 
   if (codepoint >= 0x00000800) {
     str.append(static_cast<char>(0xe0 /*0b11100000*/ | (codepoint >> 12)));
-    str.append(static_cast<char>(((codepoint >> 6) & 0x3f /*0b00111111*/) | 0x80));
+    str.append(
+        static_cast<char>(((codepoint >> 6) & 0x3f /*0b00111111*/) | 0x80));
   } else {
     str.append(static_cast<char>(0xc0 /*0b11000000*/ | (codepoint >> 6)));
   }
@@ -152,8 +153,7 @@ static inline void encode_to_utf8(const uint16_t codepoint, Str &str) {
 }
 
 static inline char parse_hexdigit(char c) {
-  if (c < 'A')
-      return static_cast<char>(c - '0');
+  if (c < 'A') return static_cast<char>(c - '0');
   c &= ~0x20;
   return static_cast<char>(c - 'A' + 10);
 }
@@ -181,14 +181,13 @@ ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseString() {
         const char escaped = _reader.current();
         if (escaped == 'u') {
           uint16_t codepoint = 0;
-          char i=0;
-          while(1)
-          {
-              _reader.move();
-              if (i >=4)
-                  break;
-              codepoint = static_cast<uint16_t>((codepoint << 4) | parse_hexdigit(_reader.current()));
-              ++i;
+          char i = 0;
+          for (;;) {
+            _reader.move();
+            if (i >= 4) break;
+            codepoint = static_cast<uint16_t>(
+                (codepoint << 4) | parse_hexdigit(_reader.current()));
+            ++i;
           }
           encode_to_utf8(codepoint, str);
           continue;

--- a/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
@@ -137,16 +137,18 @@ inline bool ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseObjectTo(
 
 template <typename Str>
 static inline void encode_to_utf8(const uint16_t codepoint, Str &str) {
+    if (codepoint < 0x80) {
+        str.append(static_cast<char>(codepoint));
+        return;
+    }
+
   if (codepoint >= 0x00000800) {
     str.append(static_cast<char>(0xe0 /*0b11100000*/ | (codepoint >> 12)));
     str.append(static_cast<char>(((codepoint >> 6) & 0x3f /*0b00111111*/) | 0x80));
-    str.append(static_cast<char>((codepoint & 0x3f /*0b00111111*/) | 0x80));
-  } else if (codepoint >= 0x00000080) {
-    str.append(static_cast<char>(0xc0 /*0b11000000*/ | (codepoint >> 6)));
-    str.append(static_cast<char>((codepoint & 0x3f /*0b00111111*/) | 0x80));
   } else {
-    str.append(static_cast<char>(codepoint));
+    str.append(static_cast<char>(0xc0 /*0b11000000*/ | (codepoint >> 6)));
   }
+  str.append(static_cast<char>((codepoint & 0x3f /*0b00111111*/) | 0x80));
 }
 
 static inline char parse_hexdigit(char c) {

--- a/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
+++ b/src/ArduinoJson/Deserialization/JsonParserImpl.hpp
@@ -136,7 +136,7 @@ inline bool ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseObjectTo(
 }
 
 template <typename Str>
-static inline void encode_to_utf8(int codepoint, Str &str) {
+static inline void encode_to_utf8(const uint16_t codepoint, Str &str) {
   if (codepoint >= 0x00000800) {
     str.append(static_cast<char>(0xe0 /*0b11100000*/ | (codepoint >> 12)));
     str.append(static_cast<char>(((codepoint >> 6) & 0x3f /*0b00111111*/) | 0x80));
@@ -180,14 +180,17 @@ ArduinoJson::Internals::JsonParser<TReader, TWriter>::parseString() {
         // replace char
         const char escaped = _reader.current();
         if (escaped == 'u') {
-          int codepoint = 0;
-          for (unsigned int i = 0; i < 4; ++i) {
-            _reader.move();
-            codepoint <<= 4;
-            codepoint += parse_hexdigit(_reader.current());
+          uint16_t codepoint = 0;
+          char i=0;
+          while(1)
+          {
+              _reader.move();
+              if (i >=4)
+                  break;
+              codepoint = static_cast<uint16_t>((codepoint << 4) | parse_hexdigit(_reader.current()));
+              ++i;
           }
-          _reader.move();
-          encode_to_utf8(static_cast<uint16_t>(codepoint), str);
+          encode_to_utf8(codepoint, str);
           continue;
         } else {
           c = Encoding::unescapeChar(escaped);

--- a/test/JsonBuffer/parse.cpp
+++ b/test/JsonBuffer/parse.cpp
@@ -77,4 +77,25 @@ TEST_CASE("JsonBuffer::parse()") {
     REQUIRE(variant.is<char*>());
     REQUIRE_THAT(variant.as<char*>(), Equals("hello"));
   }
+
+  SECTION("\\uxxxx escape: 1 byte") {
+    JsonVariant variant = jb.parse("\'\\u0041\'");
+    REQUIRE(variant.success());
+    REQUIRE(variant.is<char*>());
+    REQUIRE_THAT(variant.as<char*>(), Equals("A"));
+  }
+
+  SECTION("\\uxxxx escape: 2 bytes") {
+    JsonVariant variant = jb.parse("\'\\u00e4\'");
+    REQUIRE(variant.success());
+    REQUIRE(variant.is<char*>());
+    REQUIRE_THAT(variant.as<char*>(), Equals("\xc3\xa4")); // ä
+  }
+
+  SECTION("\\uxxxx escape: 3 bytes") {
+    JsonVariant variant = jb.parse("\'\\u3042\'");
+    REQUIRE(variant.success());
+    REQUIRE(variant.is<char*>());
+    REQUIRE_THAT(variant.as<char*>(), Equals("\xe3\x81\x82")); // あ
+  }
 }


### PR DESCRIPTION
Currently there are no unit tests for this, as I've got no idea which file would be appropriate for this kind of test case.