### PR TITLE
Specialize handling of Arduino `Stream` pointers

### DIFF
--- a/src/ArduinoJson/Serialization/serialize.hpp
+++ b/src/ArduinoJson/Serialization/serialize.hpp
@@ -34,6 +34,11 @@ template <template <typename> class TSerializer, typename TSource>
 size_t serialize(const TSource &source, Print &destination) {
   return doSerialize<TSerializer>(source, destination);
 }
+
+template <template <typename> class TSerializer, typename TSource>
+size_t serialize(const TSource &source, Print *destination) {
+  return destination ? doSerialize<TSerializer>(source, *destination) : 0;
+}
 #endif
 
 template <template <typename> class TSerializer, typename TSource>


### PR DESCRIPTION
Problem:

* Serialization of Stream* (and inherited class pointers) doesn't compile
* De-serialization compiles and produces `InvalidInput` error

This proposed fix includes null pointer checks.