### PR TITLE
Add missing `measureJson` function to the `ArduinoJson` namespace

### DIFF
--- a/src/ArduinoJson.hpp
+++ b/src/ArduinoJson.hpp
@@ -57,6 +57,7 @@ using ARDUINOJSON_NAMESPACE::deserializeJson;
 using ARDUINOJSON_NAMESPACE::deserializeMsgPack;
 using ARDUINOJSON_NAMESPACE::DynamicJsonDocument;
 using ARDUINOJSON_NAMESPACE::JsonDocument;
+using ARDUINOJSON_NAMESPACE::measureJson;
 using ARDUINOJSON_NAMESPACE::serialized;
 using ARDUINOJSON_NAMESPACE::serializeJson;
 using ARDUINOJSON_NAMESPACE::serializeJsonPretty;


### PR DESCRIPTION
I don't want to include `ArduinoJson.h` because it imports everything from the auto-generated namespace. If I include `ArduinoJson.hpp` then `measureJson` is missing.