### PR TITLE
Make sure the Arduino.h header file has been included if ARDUINO is defined

### DIFF
--- a/src/ArduinoJson/Configuration.hpp
+++ b/src/ArduinoJson/Configuration.hpp
@@ -90,6 +90,8 @@
 
 #ifdef ARDUINO
 
+#include <Arduino.h>
+
 // Enable support for Arduino's String class
 #ifndef ARDUINOJSON_ENABLE_ARDUINO_STRING
 #define ARDUINOJSON_ENABLE_ARDUINO_STRING 1
@@ -107,17 +109,17 @@
 
 #else  // ARDUINO
 
-// Enable support for Arduino's String class
+// Disable support for Arduino's String class
 #ifndef ARDUINOJSON_ENABLE_ARDUINO_STRING
 #define ARDUINOJSON_ENABLE_ARDUINO_STRING 0
 #endif
 
-// Enable support for Arduino's Stream class
+// Disable support for Arduino's Stream class
 #ifndef ARDUINOJSON_ENABLE_ARDUINO_STREAM
 #define ARDUINOJSON_ENABLE_ARDUINO_STREAM 0
 #endif
 
-// Enable support for Arduino's Print class
+// Disable support for Arduino's Print class
 #ifndef ARDUINOJSON_ENABLE_ARDUINO_PRINT
 #define ARDUINOJSON_ENABLE_ARDUINO_PRINT 0
 #endif


### PR DESCRIPTION
If `ARDUINO` is defined then it should be safe to assume `<Arduino.h>` can be included (and should be, otherwise not all features work).