### PR TITLE
Disable String reader when Stream is enabled and String derives from Stream

### DIFF
--- a/src/ArduinoJson/Deserialization/Reader.hpp
+++ b/src/ArduinoJson/Deserialization/Reader.hpp
@@ -43,7 +43,7 @@ struct BoundedReader {
 #include <ArduinoJson/Deserialization/Readers/ArduinoStreamReader.hpp>
 #endif
 
-#if ARDUINOJSON_ENABLE_ARDUINO_STRING
+#if ARDUINOJSON_ENABLE_ARDUINO_STRING && (!ARDUINOJSON_ENABLE_ARDUINO_STREAM || !STRING_IS_STREAM)
 #include <ArduinoJson/Deserialization/Readers/ArduinoStringReader.hpp>
 #endif
 


### PR DESCRIPTION
This is related to PR https://github.com/esp8266/Arduino/pull/6979 (specifically [this](https://github.com/esp8266/Arduino/pull/6979/files#diff-3d1eaec7ee8f9cdadc75a401477867a0)).
It is opened for discussion.

This would solve this error:

```
sketch/StringExample.ino.cpp:
In file included from ArduinoJson/src/ArduinoJson/Json/JsonDeserializer.hpp:7,
                 from ArduinoJson/src/ArduinoJson.hpp:34,
                 from ArduinoJson/src/ArduinoJson.h:9,
                 from ArduinoJson/examples/StringExample/StringExample.ino:13:
ArduinoJson/src/ArduinoJson/Deserialization/deserialize.hpp: In instantiation of 'ArduinoJson6161_11::DeserializationError ArduinoJson6161_11::deserialize(ArduinoJson6161_11::JsonDocument&, TStream&, ArduinoJson6161_11::NestingLimit, TFilter) [with TDeserializer = ArduinoJson6161_11::JsonDeserializer; TStream = String; TFilter = ArduinoJson6161_11::AllowAllFilter]':
ArduinoJson/src/ArduinoJson/Json/JsonDeserializer.hpp:676:39:   required from 'ArduinoJson6161_11::DeserializationError ArduinoJson6161_11::deserializeJson(ArduinoJson6161_11::JsonDocument&, TInput&, ArduinoJson6161_11::NestingLimit) [with TInput = String]'
ArduinoJson/examples/StringExample/StringExample.ino:22:29:   required from here
ArduinoJson/src/ArduinoJson/Deserialization/deserialize.hpp:61:19: error: ambiguous template instantiation for 'struct ArduinoJson6161_11::Reader<String, void>'
   61 |   Reader<TStream> reader(input);
      |                   ^~~~~~
In file included from ArduinoJson/src/ArduinoJson/Deserialization/Reader.hpp:43,
                 from ArduinoJson/src/ArduinoJson/Deserialization/deserialize.hpp:10,
                 from ArduinoJson/src/ArduinoJson/Json/JsonDeserializer.hpp:7,
                 from ArduinoJson/src/ArduinoJson.hpp:34,
                 from ArduinoJson/src/ArduinoJson.h:9,
                 from ArduinoJson/examples/StringExample/StringExample.ino:13:
ArduinoJson/src/ArduinoJson/Deserialization/Readers/ArduinoStreamReader.hpp:12:8: note: candidates are: 'template<class TSource> struct ArduinoJson6161_11::Reader<TSource, typename ArduinoJson6161_11::enable_if<ArduinoJson6161_11::is_base_of<Stream, TSource>::value>::type> [with TSource = String]'
   12 | struct Reader<TSource,
      |        ^~~~~~~~~~~~~~~
   13 |               typename enable_if<is_base_of<Stream, TSource>::value>::type> {
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ArduinoJson/src/ArduinoJson/Deserialization/Reader.hpp:47,
                 from ArduinoJson/src/ArduinoJson/Deserialization/deserialize.hpp:10,
                 from ArduinoJson/src/ArduinoJson/Json/JsonDeserializer.hpp:7,
                 from ArduinoJson/src/ArduinoJson.hpp:34,
                 from ArduinoJson/src/ArduinoJson.h:9,
                 from ArduinoJson/examples/StringExample/StringExample.ino:13:
ArduinoJson/src/ArduinoJson/Deserialization/Readers/ArduinoStringReader.hpp:10:8: note:                 'template<class TSource> struct ArduinoJson6161_11::Reader<TSource, typename ArduinoJson6161_11::enable_if<ArduinoJson6161_11::is_base_of<String, TSource>::value>::type> [with TSource = String]'
   10 | struct Reader<TSource,
      |        ^~~~~~~~~~~~~~~
   11 |               typename enable_if<is_base_of< ::String, TSource>::value>::type>
      |               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ArduinoJson/src/ArduinoJson/Json/JsonDeserializer.hpp:7,
                 from ArduinoJson/src/ArduinoJson.hpp:34,
                 from ArduinoJson/src/ArduinoJson.h:9,
                 from ArduinoJson/examples/StringExample/StringExample.ino:13:
ArduinoJson/src/ArduinoJson/Deserialization/deserialize.hpp:61:19: error: 'ArduinoJson6161_11::Reader<String, void> reader' has incomplete type
   61 |   Reader<TStream> reader(input);
      |                   ^~~~~~
Using library ArduinoJson at version 6.16.1 in folder: ArduinoJson 
```
