### PR TITLE
Fixed error "nullptr is defined as a macro"

### DIFF
--- a/src/ArduinoJson/Configuration.hpp
+++ b/src/ArduinoJson/Configuration.hpp
@@ -5,6 +5,9 @@
 #pragma once
 
 #if __cplusplus >= 201103L
+#ifdef nullptr
+#undef nullptr
+#endif
 #define ARDUINOJSON_HAS_LONG_LONG 1
 #define ARDUINOJSON_HAS_NULLPTR 1
 #define ARDUINOJSON_HAS_RVALUE_REFERENCES 1


### PR DESCRIPTION
Hey, there I fixed an issue with:

5:2: error: #error nullptr is defined as a macro. Remove the faulty #define or #undef nullptr
 #error nullptr is defined as a macro. Remove the faulty #define or #undef nullptr

I got this error while compiling any ArduinoJson code on ESP8266 Visuino Project
