### PR TITLE
Advertise ESP-IDF compatibility in library.json

### DIFF
--- a/extras/ci/platformio.sh
+++ b/extras/ci/platformio.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-pip install --user platformio
+pip3 install --user platformio
 
 case $BOARD in
 uno)

--- a/extras/ci/platformio.sh
+++ b/extras/ci/platformio.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-pip3 install --user platformio
+pip install --user platformio
 
 case $BOARD in
 uno)

--- a/library.json
+++ b/library.json
@@ -16,6 +16,6 @@
     ".github",
     "extras"
   ],
-  "frameworks": "arduino",
+  "frameworks": ["arduino", "espidf"],
   "platforms": "*"
 }


### PR DESCRIPTION
Per [PlatformIO forum thread](https://community.platformio.org/t/arduinojson-with-esp-idf/19027) this library can also be used with ESP-IDF. It's just that PlatformIO refuses by default to use this library in a project that has `framework = espidf` and not `arduino` because the `library.json` only advertises `arduino` compatibility and a user needs to do `lib_compat_mode = off` to bypass the compatibility check.

Per [docs](https://docs.platformio.org/en/latest/librarymanager/config.html#frameworks) I've expanded the `library.json`. 

You might also want to expand the detection code for 

https://github.com/bblanchon/ArduinoJson/blob/322d13de0d9e42862321af458a7438c0e7aa15a2/src/ArduinoJson/Configuration.hpp#L23-L34

So that the macro ends up having the value 1, the same as in Arduino. The check `#if defined(IDF_VER)` might e.g. be used for that (defined during build process `-DIDF_VER=\"3.40200.210118\"`), or check on `__xtensa__` (compiler does `#define __xtensa__ 1`). I left that out in this PR because I'm not 100% sure on what you want this macro value to be in an ESP-IDF environment.