### PR TITLE
Add extras folder to .mbedignore

### DIFF
--- a/.mbedignore
+++ b/.mbedignore
@@ -4,3 +4,4 @@ fuzzing/
 scripts/
 test/
 third-party/
+extras/

--- a/.mbedignore
+++ b/.mbedignore
@@ -1,7 +1,3 @@
 .github/
 examples/
-fuzzing/
-scripts/
-test/
-third-party/
 extras/


### PR DESCRIPTION
This commit adds the extras folder to the .mbedignore file. Some code in the extras folder causes build failures when compiling for Mbed OS (shown below):

```
[Error] Issue1189.cpp@12,8: 'ArduinoJson6173_71::JsonDocument::JsonDocument(const ArduinoJson6173_71::JsonDocument&)' is private within this context
[Error] Issue1189.cpp@12,8: 'ArduinoJson6173_71::JsonDocument::~JsonDocument()' is protected within this context
```

Among other errors. Simply ignoring this directory from the Mbed-OS build is sufficient to fix this problem.