### PR TITLE
Fix JsonDocument::clear() does not clear the KEY_IS_OWNED flag in VariantData's _flags variable

### DIFF
--- a/src/ArduinoJson/Document/JsonDocument.hpp
+++ b/src/ArduinoJson/Document/JsonDocument.hpp
@@ -32,6 +32,7 @@ class JsonDocument : public Visitable {
 
   void clear() {
     _pool.clear();
+    _data.init();
     _data.setNull();
   }
 


### PR DESCRIPTION
If JsonDocument::clear() is called, the KEY_IS_OWNED flag of JsonDocument's _data variable is not cleared.

Currently, JsonDocument::clear() calls _data.setNull, which calls setType(VALUE_IS_NULL), and setType preserves the KEY_IS_OWNED flag due to the '_flags &= KEY_IS_OWNED;' statement.

In this pull request, the _data.init() call was added to the JsonDocument::clear() method so that the KEY_IS_OWNED flag is cleared.