### PR TITLE
Set build.libArchive to false.

### DIFF
--- a/library.json
+++ b/library.json
@@ -17,5 +17,8 @@
     "extras"
   ],
   "frameworks": "*",
-  "platforms": "*"
+  "platforms": "*",
+  "build": {
+    "libArchive": false
+  }
 }


### PR DESCRIPTION
When attempting to build on the `native` platformIO framework, it attempts to compile a linkable `.a` despite this library being header-only. In https://github.com/bblanchon/ArduinoJson/issues/731 it was suggested to use `libArchive` (which did not seem to work) but the submitter eventually used `lib_archive` at the project level.

This is, I assume, a better fix as the project-level setting will apply to all dependencies. I was able to build with this setting, at least.