### PR TITLE
Added support for std::string_view

### DIFF
--- a/src/ArduinoJson/Strings/StdStringAdapter.hpp
+++ b/src/ArduinoJson/Strings/StdStringAdapter.hpp
@@ -51,8 +51,51 @@ class StdStringAdapter {
   const TString* _str;
 };
 
+template <typename TStringView>
+class StdStringViewAdapter {
+ public:
+  StdStringViewAdapter(TStringView strView) : _strView(strView) {}
+
+  void copyTo(char* p, size_t n) const {
+    memcpy(p, _strView.data(), n);
+  }
+
+  bool isNull() const {
+    return false;
+  }
+
+  int compare(const char* other) const {
+    if (!other)
+      return 1;
+    return _strView.compare(other);
+  }
+
+  bool equals(const char* expected) const {
+    if (!expected)
+      return false;
+    return _strView == expected;
+  }
+
+  size_t size() const {
+    return _strView.size();
+  }
+
+  const char* begin() const {
+    return _strView.data();
+  }
+
+  typedef storage_policies::store_by_copy storage_policy;
+
+ private:
+  TStringView _strView;
+};
+
 template <typename TCharTraits, typename TAllocator>
 struct IsString<std::basic_string<char, TCharTraits, TAllocator> > : true_type {
+};
+
+template <typename TCharTraits>
+struct IsString<std::basic_string_view<char, TCharTraits> > : true_type {
 };
 
 template <typename TCharTraits, typename TAllocator>
@@ -60,6 +103,12 @@ inline StdStringAdapter<std::basic_string<char, TCharTraits, TAllocator> >
 adaptString(const std::basic_string<char, TCharTraits, TAllocator>& str) {
   return StdStringAdapter<std::basic_string<char, TCharTraits, TAllocator> >(
       str);
+}
+
+template <typename TCharTraits>
+inline StdStringViewAdapter<std::basic_string_view<char, TCharTraits> >
+adaptString(const std::basic_string_view<char, TCharTraits>& str) {
+  return StdStringViewAdapter<std::basic_string_view<char, TCharTraits> >(str);
 }
 
 }  // namespace ARDUINOJSON_NAMESPACE


### PR DESCRIPTION
I was missing support for std::string_view in ArduinoJson, I don't have much knowledge about the internals of ArduinoJson and I tested my implementation only on ESP32 with esp-idf and without any arduino libraries.