### PR TITLE
Change variable name so doesn't cause issues on Zephyr OS

### DIFF
--- a/src/ArduinoJson/Json/Latch.hpp
+++ b/src/ArduinoJson/Json/Latch.hpp
@@ -22,14 +22,14 @@ class Latch {
   }
 
   int last() const {
-    return _current;
+    return __current;
   }
 
   FORCE_INLINE char current() {
     if (!_loaded) {
       load();
     }
-    return _current;
+    return __current;
   }
 
  private:
@@ -40,12 +40,12 @@ class Latch {
     if (c <= 0)
       _ended = true;
 #endif
-    _current = static_cast<char>(c > 0 ? c : 0);
+    __current = static_cast<char>(c > 0 ? c : 0);
     _loaded = true;
   }
 
   TReader _reader;
-  char _current;
+  char __current;
   bool _loaded;
 #if ARDUINOJSON_DEBUG
   bool _ended;


### PR DESCRIPTION
There is a define of _current in zephyr. Causes the code to not compile.

Defined here..

https://github.com/zephyrproject-rtos/zephyr/blob/cd9421a45e7254de6be913debe153dbac4be1e91/include/kernel_structs.h#L186

Suggest changing the name to __ Don't know if it's your problem or theirs.