### PR TITLE
Add clang-tidy to CI

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+---
+Checks: '
+    -clang-analyzer-security.insecureAPI.strcpy,
+'
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*'
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:
+...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,22 @@ jobs:
       - name: Diff
         run: git diff --exit-code
 
+  clang-tidy:
+    name: Clang-Tidy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install
+        run: sudo apt-get install -y clang-tidy cmake ninja-build
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure
+        run: cmake -G Ninja -DCMAKE_CXX_CLANG_TIDY="clang-tidy" -DCMAKE_BUILD_TYPE=Debug .
+        env:
+          CC: clang-10
+          CXX: clang++-10
+      - name: Build
+        run: cmake --build .
+
   gcc:
     name: GCC
     needs: clang-format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           CC: clang-10
           CXX: clang++-10
       - name: Check
-        run: cmake --build .
+        run: cmake --build . -- -k 0
 
   gcc:
     name: GCC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           CC: clang-10
           CXX: clang++-10
-      - name: Build
+      - name: Check
         run: cmake --build .
 
   gcc:


### PR DESCRIPTION
Adding clang-tidy static analyzer step to CI, as discussed in #1574.

Note: currently, the CI fails due to the clang-tidy warnings. These are to be reviewed and fixed/ignored at a later time.