### PR TITLE
Add CIFuzz

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,24 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'arduinojson'
+        dry-run: false
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'arduinojson'
+        fuzz-seconds: 600
+        dry-run: false
+    - name: Upload Crash
+      uses: actions/upload-artifact@v1
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Adds [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/). This will run the fuzzers during pull requests for 600 seconds. The time can be modified.

CIFuzz is an addition to ArduinoJson's OSS-fuzz integration. The documentation for CIFuzz can be found here: https://google.github.io/oss-fuzz/getting-started/continuous-integration/

The existing fuzzers are found here: https://github.com/bblanchon/ArduinoJson/tree/6.x/extras/fuzzing