### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ install(
     RUNTIME DESTINATION
         ${CMAKE_INSTALL_BINDIR}
 )
-
+ 
 include(CMakePackageConfigHelpers)
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.14.0") 
@@ -82,9 +82,4 @@ install(
         include
 )
 
-install(
-    DIRECTORY
-        "${CMAKE_CURRENT_SOURCE_DIR}/ArduinoJson"
-    DESTINATION
-        include
-)
+


### PR DESCRIPTION
This entire file is not needed due to the fact that there is not a program reading from this txt file, rather use the functions listed in your __init__ file. I chopped of the ending function because how can we install the ArduinoJson Package if this file does not have access to it in the first place.