### PR TITLE
Fix comma tests.

### DIFF
--- a/extras/tests/JsonDeserializer/object.cpp
+++ b/extras/tests/JsonDeserializer/object.cpp
@@ -100,7 +100,7 @@ TEST_CASE("deserialize JSON object") {
       REQUIRE(obj["key"] == "value");
     }
 
-    SECTION("Before the colon") {
+    SECTION("Before the comma") {
       DeserializationError err =
           deserializeJson(doc, "{\"key1\":\"value1\" ,\"key2\":\"value2\"}");
       JsonObject obj = doc.as<JsonObject>();
@@ -112,9 +112,9 @@ TEST_CASE("deserialize JSON object") {
       REQUIRE(obj["key2"] == "value2");
     }
 
-    SECTION("After the colon") {
+    SECTION("After the comma") {
       DeserializationError err =
-          deserializeJson(doc, "{\"key1\":\"value1\" ,\"key2\":\"value2\"}");
+          deserializeJson(doc, "{\"key1\":\"value1\", \"key2\":\"value2\"}");
       JsonObject obj = doc.as<JsonObject>();
 
       REQUIRE(err == DeserializationError::Ok);


### PR DESCRIPTION
 extras/tests/JsonDeserializer/object.cpp

The tests for space before and after the **comma** were mislabeled as bofore and after **colon**.
The test for space after the comma was a copy of the before test, probably copied and not updated.