### PR TITLE
enable recognizing Arduino's `String` when emulating API on 64 bits

### DIFF
--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -54,8 +54,8 @@ struct has_length<
 template <class T>
 struct has_length<
     T, typename enable_if<
-           is_same<decltype(declval<const T>().length()), unsigned int>::value>::type>
-    : true_type {};
+           is_same<decltype(declval<const T>().length()),
+                   unsigned int>::value>::type> : true_type {};
 
 // size_t size() const
 // - std::string

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -46,15 +46,15 @@ template <class T, class = void>
 struct has_length : false_type {};
 
 template <typename T, typename... Rest>
-struct is_any : std::false_type {};
+struct is_any : false_type {};
 
 template <typename T, typename First>
-struct is_any<T, First> : std::is_same<T, First> {};
+struct is_any<T, First> : is_same<T, First> {};
 
 template <typename T, typename First, typename... Rest>
 struct is_any<T, First, Rest...>
-    : std::integral_constant<bool, std::is_same<T, First>::value ||
-                                       is_any<T, Rest...>::value> {};
+    : integral_constant<bool, is_same<T, First>::value ||
+                                  is_any<T, Rest...>::value> {};
 
 template <class T>
 struct has_length<

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -45,21 +45,10 @@ struct has_data<T,
 template <class T, class = void>
 struct has_length : false_type {};
 
-template <typename T, typename... Rest>
-struct is_any : false_type {};
-
-template <typename T, typename First>
-struct is_any<T, First> : is_same<T, First> {};
-
-template <typename T, typename First, typename... Rest>
-struct is_any<T, First, Rest...>
-    : integral_constant<bool, is_same<T, First>::value ||
-                                  is_any<T, Rest...>::value> {};
-
 template <class T>
-struct has_length<
-    T, typename enable_if<is_any<decltype(declval<const T>().length()), size_t,
-                                 unsigned int>::value>::type> : true_type {};
+struct has_length<T, typename enable_if<is_unsigned<
+                         decltype(declval<const T>().length())>::value>::type>
+    : true_type {};
 
 // size_t size() const
 // - std::string

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -39,6 +39,7 @@ struct has_data<T,
     : true_type {};
 
 // size_t length() const
+// unsigned int length() const
 // - String
 
 template <class T, class = void>
@@ -48,6 +49,12 @@ template <class T>
 struct has_length<
     T, typename enable_if<
            is_same<decltype(declval<const T>().length()), size_t>::value>::type>
+    : true_type {};
+
+template <class T>
+struct has_length<
+    T, typename enable_if<
+           is_same<decltype(declval<const T>().length()), unsigned int>::value>::type>
     : true_type {};
 
 // size_t size() const

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -45,16 +45,21 @@ struct has_data<T,
 template <class T, class = void>
 struct has_length : false_type {};
 
-template <class T>
-struct has_length<
-    T, typename enable_if<
-           is_same<decltype(declval<const T>().length()), size_t>::value>::type>
-    : true_type {};
+template <typename T, typename... Rest>
+struct is_any : std::false_type {};
+
+template <typename T, typename First>
+struct is_any<T, First> : std::is_same<T, First> {};
+
+template <typename T, typename First, typename... Rest>
+struct is_any<T, First, Rest...>
+    : std::integral_constant<bool, std::is_same<T, First>::value ||
+                                       is_any<T, Rest...>::value> {};
 
 template <class T>
 struct has_length<
-    T, typename enable_if<is_same<decltype(declval<const T>().length()),
-                                  unsigned int>::value>::type> : true_type {};
+    T, typename enable_if<is_any<decltype(declval<const T>().length()), size_t,
+                                 unsigned int>::value>::type> : true_type {};
 
 // size_t size() const
 // - std::string

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -46,8 +46,8 @@ template <class T, class = void>
 struct has_length : false_type {};
 
 template <class T>
-struct has_length<T, typename enable_if<is_unsigned<
-                         decltype(declval<const T>().length())>::value>::type>
+struct has_length<T, typename enable_if<is_unsigned<decltype(
+                         declval<const T>().length())>::value>::type>
     : true_type {};
 
 // size_t size() const

--- a/src/ArduinoJson/Strings/StringTraits.hpp
+++ b/src/ArduinoJson/Strings/StringTraits.hpp
@@ -53,9 +53,8 @@ struct has_length<
 
 template <class T>
 struct has_length<
-    T, typename enable_if<
-           is_same<decltype(declval<const T>().length()),
-                   unsigned int>::value>::type> : true_type {};
+    T, typename enable_if<is_same<decltype(declval<const T>().length()),
+                                  unsigned int>::value>::type> : true_type {};
 
 // size_t size() const
 // - std::string


### PR DESCRIPTION
When emulating Arduino API on 64 bits host, `size_t` and `unsigned int` are different.

Arduino's `String` is then not recognized by `StringTraits` thus preventing compilation with tons of errors.

This proposal adds the missing matching.
It changes nothing when compiling on 32 bits archs.

This issue was introduced by c89a2025ce11ff741a75567ce676e8f3b9cdd761.