### PR TITLE
fix parseNumber returning zero for finite values with negative exponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ HEAD
   Version 7.3 introduced a new way to detect string literals, but it fails in some edge cases.
   I could not find a way to fix it, so I chose to remove the optimization rather than keep it broken.
 * Replace the "extension slots" mechanism with a memory pool dedicated to 8-byte values.
+* Fix `parseNumber()` returning zero for a finite value written with many
+  digits and a negative exponent (e.g. `1` followed by 300 zeros and `e-30`)
 
 > ### BREAKING CHANGES
 >

--- a/extras/tests/Numbers/parseDouble.cpp
+++ b/extras/tests/Numbers/parseDouble.cpp
@@ -9,6 +9,8 @@
 #include <ArduinoJson.hpp>
 #include <catch.hpp>
 
+#include <string>
+
 using namespace ArduinoJson::detail;
 
 void checkDouble(const char* input, double expected) {
@@ -92,6 +94,15 @@ TEST_CASE("parseNumber<double>()") {
   SECTION("NaN") {
     checkDoubleNaN("NaN");
     checkDoubleNaN("nan");
+  }
+
+  SECTION("Large magnitude reduced by a negative exponent") {
+    // "1" followed by 300 zeros is 1e300; "e-30" scales it down to 1e270,
+    // which is a finite double and must not collapse to zero.
+    checkDouble((std::string("1") + std::string(300, '0') + "e-30").c_str(),
+                1e270);
+    checkDouble((std::string("-1") + std::string(300, '0') + "e-30").c_str(),
+                -1e270);
   }
 
   SECTION("Overflow exponent with decimal part") {  // Issue #2220

--- a/src/ArduinoJson/Numbers/parseNumber.hpp
+++ b/src/ArduinoJson/Numbers/parseNumber.hpp
@@ -196,14 +196,19 @@ inline Number parseNumber(const char* s) {
       s++;
     }
 
+    // Largest power of ten the binary table can apply to the mantissa; beyond
+    // this the result saturates to infinity or zero.
+    const int exponent_limit =
+        (1 << traits::positiveBinaryPowersOfTen().size()) - 1;
+
     while (isdigit(*s)) {
       exponent = exponent * 10 + (*s - '0');
-      if (exponent + exponent_offset > traits::exponent_max) {
-        if (negative_exponent)
-          return Number(is_negative ? -0.0f : 0.0f);
-        else
-          return Number(is_negative ? -traits::inf() : traits::inf());
-      }
+      int effective_exponent =
+          exponent_offset + (negative_exponent ? -exponent : exponent);
+      if (effective_exponent > exponent_limit)
+        return Number(is_negative ? -traits::inf() : traits::inf());
+      if (effective_exponent < -exponent_limit)
+        return Number(is_negative ? -0.0f : 0.0f);
       s++;
     }
     if (negative_exponent)


### PR DESCRIPTION
Reading a numeric string as a number, for example `doc["x"].as<double>()` on
the value "1" followed by 300 zeros and `e-30` (which is 1e270), returns 0.

1. the exponent overflow guard adds the parsed exponent to `exponent_offset` even when the exponent is negative, so a large positive offset combined with a negative exponent trips the guard and yields 0 instead of scaling the mantissa back down.
2. saturating at `exponent_max` is also too tight once the mantissa carries extra digits, which is why the check now uses the reach of the binary powers-of-ten table.

Compute the effective exponent with its real sign and only saturate to inf/0 past what the table can represent; `multiplyByPowerOfTen()` handles everything in range, including subnormals.