### PR TITLE
bound ext header read in MsgPackExtension::fromJson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ ArduinoJson: change log
 HEAD
 ----
 
+* Fix buffer overrun when reading a raw string with a truncated MessagePack extension header as `MsgPackExtension`
 * Don't store string literals by pointer anymore (issue #2189)
   Version 7.3 introduced a new way to detect string literals, but it fails in some edge cases.
   I could not find a way to fix it, so I chose to remove the optimization rather than keep it broken.

--- a/extras/tests/JsonVariant/as.cpp
+++ b/extras/tests/JsonVariant/as.cpp
@@ -264,6 +264,18 @@ TEST_CASE("JsonVariant::as()") {
     REQUIRE(variant.as<MsgPackExtension>().data() == nullptr);
   }
 
+  SECTION("as<MsgPackExtension>() with truncated ext header") {
+    // ext 8/16/32 headers whose size bytes run past the buffer
+    REQUIRE(variant.set(serialized("\xc7"_s)));
+    REQUIRE(variant.as<MsgPackExtension>().data() == nullptr);
+
+    REQUIRE(variant.set(serialized("\xc8"_s)));
+    REQUIRE(variant.as<MsgPackExtension>().data() == nullptr);
+
+    REQUIRE(variant.set(serialized("\xc9"_s)));
+    REQUIRE(variant.as<MsgPackExtension>().data() == nullptr);
+  }
+
   SECTION("to<JsonObject>()") {
     JsonObject obj = variant.to<JsonObject>();
     obj["key"] = "value";

--- a/src/ArduinoJson/MsgPack/MsgPackExtension.hpp
+++ b/src/ArduinoJson/MsgPack/MsgPackExtension.hpp
@@ -104,6 +104,8 @@ struct Converter<MsgPackExtension> : private detail::VariantAttorney {
 
     if (code >= 0xc7 && code <= 0xc9) {
       uint8_t sizeBytes = uint8_t(1 << (code - 0xc7));
+      if (rawstr.size() < size_t(1) + sizeBytes)
+        return {};
       for (uint8_t i = 0; i < sizeBytes; i++)
         payloadSize = (payloadSize << 8) | p[1 + i];
       headerSize = uint8_t(2 + sizeBytes);


### PR DESCRIPTION
`MsgPackExtension::fromJson` reads the ext 8/16/32 size bytes straight out of the raw string:
- for code 0xc7/0xc8/0xc9 it reads `p[1 .. sizeBytes]` before any length check, so a raw string shorter than the header runs off the end of the `StringNode` buffer
- `MsgPackBinary::fromJson` right next to it already guards the same reads with `n >= 2/3/5`, this converter just never got the equivalent guard

A one-byte raw string `"\xc9"` (reachable via `serialized()`) is enough to trigger it. Under `-fsanitize=address`:

    heap-buffer-overflow READ ... in MsgPackExtension::fromJson (MsgPackExtension.hpp)
    0 bytes after 16-byte region allocated by ResourceManager::saveString

Bounded the size-byte read against `rawstr.size()` before the loop, and added the truncated-header cases to the existing `as<MsgPackExtension>()` test (they abort under ASan without the fix).